### PR TITLE
Fix overflow panic by explicitly using wrapping ops.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@
 //!
 //! ```
 
+#![feature(core)]
+
 extern crate rand;
 
 mod pcg;

--- a/src/pcg.rs
+++ b/src/pcg.rs
@@ -49,7 +49,8 @@ impl Rng for PcgRng {
     #[inline(always)]
     fn next_u32(&mut self) -> u32 {
         let old = self.state;
-        self.state = old * 6364136223846793005 + self.inc;
+        self.state = old.wrapping_mul(6364136223846793005)
+                        .wrapping_add(self.inc);
         let xor = (((old >> 18) ^ old) >> 27) as u32;
         let rot = old >> 59 as u32;
         let out = (xor >> rot) | (xor << ((-rot) & 31));


### PR DESCRIPTION
This is necessary, because wrapping addition and multiplication was
recently made opt-in.
