### PR TITLE
Added support for Serde through a "serde_support" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,8 @@ authors = ["Coda Hale <coda.hale@gmail.com>"]
 [dependencies]
 rand = "*"
 rustc-serialize = "*"
+serde = { version = "1.*.*", optional = true }
+serde_derive = { version = "1.*.*", optional = true }
+
+[features]
+serde_support = ["serde", "serde_derive"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,12 @@
 extern crate rand;
 extern crate rustc_serialize;
 
+#[cfg(feature = "serde_support")]
+extern crate serde;
+#[cfg(feature = "serde_support")]
+#[macro_use]
+extern crate serde_derive;
+
 mod pcg;
 
 pub use pcg::PcgRng;

--- a/src/pcg.rs
+++ b/src/pcg.rs
@@ -10,6 +10,7 @@ use rand::{Rng, SeedableRng, Rand};
 /// This particular implementation uses a 128-bit state value, has a period of 2^64, and uses the
 /// `XSH-RR` output function.
 #[derive(Debug, Clone, RustcEncodable, RustcDecodable)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct PcgRng {
     state: u64,
     inc: u64,


### PR DESCRIPTION
 - Added optional `serde` and `serde_derive` features that are included when the "serde_support" feature is enabled
 - Conditionally derive `Serialize` and `Deserialize` for `PcgRand` when the "serde_support" feature is enabled